### PR TITLE
add material-ui and tap-event

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,13 +1,24 @@
+// 3rd Party
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Router, Route, browserHistory, IndexRoute } from 'react-router'
+import injectTapEventPlugin from 'react-tap-event-plugin';
+import { Router, Route, browserHistory, IndexRoute } from 'react-router';
 
+// Project
 import LandingPage from './LandingPage';
 import App from './App';
 import ProjectBox from './ProjectBox';
 import ProjectPage from './containers/ProjectPage';
 import SignupForm from './SignupForm';
 import SignIn from './SignIn';
+
+
+// Needed for onTouchTap
+// Can go away when react 1.0 release
+// Check this repo:
+// https://github.com/zilverline/react-tap-event-plugin
+injectTapEventPlugin();
+
 
 const routes = (
   <Router history={browserHistory}>

--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
     "jquery": "^2.2.1",
     "jwt-simple": "^0.4.1",
     "marked": "^0.3.5",
+    "material-ui": "^0.14.4",
     "moment": "^2.11.2",
     "mongoose": "^4.4.4",
     "morgan": "^1.6.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-router": "^2.0.0",
+    "react-tap-event-plugin": "^0.2.2",
     "superagent": "^1.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds Material-UI and [react-tap-event-plugin](https://github.com/zilverline/react-tap-event-plugin) to the package.json

It also instantiates react-tap-event-plugin in index.js per the [instructions for Material-UI](http://www.material-ui.com/#/get-started/installation)
